### PR TITLE
Allow passing arguments when preloading explicitly

### DIFF
--- a/lib/prelude.rb
+++ b/lib/prelude.rb
@@ -9,8 +9,8 @@ module Prelude
     records.each { |r| r.prelude_preloader = preloader }
   end
 
-  def self.preload(records, method)
-    wrap(records).each(&method)
+  def self.preload(records, method, *args)
+    wrap(records).each { |record| record.public_send(method, *args) }
   end
 end
 

--- a/spec/prelude_spec.rb
+++ b/spec/prelude_spec.rb
@@ -149,4 +149,29 @@ describe Prelude do
     expect(records.map(&:foo)).to eq(["bar"]*4)
     expect(call_count).to eq(1)
   end
+
+  it 'should preload when called explicitly with arguments' do
+    call_counts = {arg1: 0, arg2: 0}
+    klass = Class.new do
+      include Prelude::Preloadable
+
+      define_prelude(:foo) do |records, arg|
+        call_counts[arg] += 1
+        records.index_with(arg)
+      end
+    end
+
+    records = 4.times.map { klass.new }
+    expect(call_counts).to eq(arg1: 0, arg2: 0)
+
+    Prelude.preload(records, :foo, :arg1)
+    expect(call_counts).to eq(arg1: 1, arg2: 0)
+
+    Prelude.preload(records, :foo, :arg2)
+    expect(call_counts).to eq(arg1: 1, arg2: 1)
+
+    expect(records.map { |record| record.foo(:arg1) }).to eq([:arg1]*4)
+    expect(records.map { |record| record.foo(:arg2) }).to eq([:arg2]*4)
+    expect(call_counts).to eq(arg1: 1, arg2: 1)
+  end
 end


### PR DESCRIPTION
Prior to this commit we weren't forwarding along the arguments, so in
order to preload explicitly with arguments we'd have to build a
Preloader ourselves and call `fetch` on it.