### PR TITLE
Inheritance

### DIFF
--- a/lib/prelude.rb
+++ b/lib/prelude.rb
@@ -5,7 +5,7 @@ require 'active_support'
 
 module Prelude
   def self.wrap(records)
-    preloader = Preloader.new(records.first.class, records)
+    preloader = Preloader.new(records)
     records.each { |r| r.prelude_preloader = preloader }
   end
 

--- a/lib/prelude/preloadable.rb
+++ b/lib/prelude/preloadable.rb
@@ -37,7 +37,7 @@ module Prelude
           return preloaded_values[key] if preloaded_values.key?(key)
 
           unless @prelude_preloader
-            @prelude_preloader = Preloader.new(self.class, [self])
+            @prelude_preloader = Preloader.new([self])
           end
 
           @prelude_preloader.fetch(name, *args)

--- a/lib/prelude/preloadable.rb
+++ b/lib/prelude/preloadable.rb
@@ -22,6 +22,12 @@ module Prelude
         @prelude_methods ||= {}
       end
 
+      # Copy parent prelude methods to subclasses
+      def inherited(subclass)
+        subclass.prelude_methods.merge!(prelude_methods)
+        super
+      end
+
       # Define how to preload a given method
       def define_prelude(name, &blk)
         prelude_methods[name] = Prelude::Method.new(&blk)

--- a/lib/prelude/preloader.rb
+++ b/lib/prelude/preloader.rb
@@ -1,20 +1,21 @@
 module Prelude
   class Preloader
-    def initialize(klass, records)
-      @klass = klass
+    def initialize(records)
       @records = records
     end
 
     def fetch(name, *args)
-      method = @klass.prelude_methods.fetch(name)
+      @records.group_by(&:class).flat_map do |klass, records|
+        method = klass.prelude_methods.fetch(name)
 
-      # Load and set the results for each record
-      results = preload(method, args)
-      @records.each do |record|
-        record.set_preloaded_value_for(name, args, results[record])
+        # Load and set the results for each record
+        results = preload(method, args)
+        records.each do |record|
+          record.set_preloaded_value_for(name, args, results[record])
+        end
+
+        results
       end
-
-      results
     end
 
     private

--- a/spec/prelude_spec.rb
+++ b/spec/prelude_spec.rb
@@ -17,6 +17,39 @@ describe Prelude do
     expect(klass.new.number).to eq(42)
   end
 
+  it 'should allow inheritance' do
+    parent_class = Class.new do
+      include Prelude::Preloadable
+
+      define_prelude(:parent_number) do |records|
+        Hash.new { |h, k| h[k] = 42 } # answer is always 42
+      end
+
+      define_prelude(:overridden_number) do |records|
+        Hash.new { |h, k| h[k] = 12 } # answer is always 12
+      end
+    end
+
+    child_class = Class.new(parent_class) do |records|
+      define_prelude(:child_number) do |records|
+        Hash.new { |h, k| h[k] = 77 } # answer is always 77
+      end
+
+      define_prelude(:overridden_number) do |records|
+        Hash.new { |h, k| h[k] = 54 } # answer is always 54
+      end
+    end
+
+    expect(parent_class.new.parent_number).to eq(42)
+    expect(child_class.new.parent_number).to eq(42)
+
+    expect(parent_class.new).not_to respond_to(:child_number)
+    expect(child_class.new.child_number).to eq(77)
+
+    expect(parent_class.new.overridden_number).to eq(12)
+    expect(child_class.new.overridden_number).to eq(54)
+  end
+
   it 'should be able to batch multiple calls into one' do
     call_count = 0
 

--- a/spec/prelude_spec.rb
+++ b/spec/prelude_spec.rb
@@ -48,6 +48,13 @@ describe Prelude do
 
     expect(parent_class.new.overridden_number).to eq(12)
     expect(child_class.new.overridden_number).to eq(54)
+
+    parent = parent_class.new
+    child = child_class.new
+    Prelude.preload([parent, child], :overridden_number)
+
+    expect(parent.overridden_number).to eq(12)
+    expect(child.overridden_number).to eq(54)
   end
 
   it 'should be able to batch multiple calls into one' do


### PR DESCRIPTION
Allow child classes to inherit prelude methods 
---

This commit copies over the prelude methods from the parent class to any
subclasses that inherit from it. Otherwise the child class gets a
`KeyError` when calling its prelude-defined method.

Allow preloading multiple class types at once
---

If we can inherit batch methods in child classes, then we may want to
preload both parent and child classes at the same time.

This commit makes that possible by grouping records by class when
preloading, rather than always taking the first class.

cc @latentflip